### PR TITLE
Fixed some issues:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 # CNET Makefile
 
 CC = g++
-CFLAGS  = -pthread -Wall -g -stdlib=libc++
+CFLAGS  = -pthread
 
 objects = Router Client DNS ProxyRouter
 all: $(objects)
 
 $(objects): %: %.cpp
-	$(CC) $(CFLAGS) -o ./executable/$@ $<
+	$(CC) $(CFLAGS) -o ./$@ $<
+clean:
+	rm -rf $(objects)

--- a/ProxyRouter.cpp
+++ b/ProxyRouter.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string>
+#include <cstring>
 #include <assert.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>

--- a/Router.cpp
+++ b/Router.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string>
+#include <cstring>
 #include <assert.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>


### PR DESCRIPTION
1) library 'cstring' was not included but its functions were being used i.e strlen, memset.
2) Makefile was not working properly on my machine (I'm using POP OS based on Ubuntu).
3) Now you can type 'make clean' to remove all binaries created by 'make all'.